### PR TITLE
Modify detail view to exclude future questions

### DIFF
--- a/mysite/polls/test.py
+++ b/mysite/polls/test.py
@@ -66,3 +66,28 @@ class QuestionModelTests(TestCase):
         )
         recent_question = Question(pub_date=time)
         self.assertIs(recent_question.was_published_recently(), True)
+
+    class QuestionDetailViewTests(TestCase):
+        def test_future_question(self):
+            """
+            The detail view of a question with a pub_date in the future
+            returns a 404 not found.
+            """
+            future_question = create_question(
+                question_text="Future question.", days=5
+            )
+            url = reverse("polls:detail", args=(future_question.id,))
+            response = self.client.get(url)
+            self.assertEqual(response.status_code, 404)
+
+        def test_past_question(self):
+            """
+            The detail view of a question with a pub_date in the past
+            displays the question's text.
+            """
+            past_question = create_question(
+                question_text="Past Question.", days=-5
+            )
+            url = reverse("polls:detail", args=(past_question.id,))
+            response = self.client.get(url)
+            self.assertContains(response, past_question.question_text)

--- a/mysite/polls/test.py
+++ b/mysite/polls/test.py
@@ -68,11 +68,7 @@ class QuestionModelTests(TestCase):
         self.assertIs(recent_question.was_published_recently(), True)
 
     class QuestionDetailViewTests(TestCase):
-        def test_future_question(self):
-            """
-            The detail view of a question with a pub_date in the future
-            returns a 404 not found.
-            """
+        def test_should_display_404page_with_future_question(self):
             future_question = create_question(
                 question_text="Future question.", days=5
             )
@@ -80,11 +76,7 @@ class QuestionModelTests(TestCase):
             response = self.client.get(url)
             self.assertEqual(response.status_code, 404)
 
-        def test_past_question(self):
-            """
-            The detail view of a question with a pub_date in the past
-            displays the question's text.
-            """
+        def test_should_display_past_questions(self):
             past_question = create_question(
                 question_text="Past Question.", days=-5
             )

--- a/mysite/polls/test.py
+++ b/mysite/polls/test.py
@@ -68,13 +68,13 @@ class QuestionModelTests(TestCase):
         self.assertIs(recent_question.was_published_recently(), True)
 
     class QuestionDetailViewTests(TestCase):
-        def test_should_display_404page_with_future_question(self):
+        def test_should_display_404_with_future_question(self):
             future_question = create_question(
                 question_text="Future question.", days=5
             )
             url = reverse("polls:detail", args=(future_question.id,))
             response = self.client.get(url)
-            self.assertEqual(response.status_code, 404)
+            self.assertEqual(404, response.status_code)
 
         def test_should_display_past_questions(self):
             past_question = create_question(

--- a/mysite/polls/views.py
+++ b/mysite/polls/views.py
@@ -21,6 +21,12 @@ class DetailView(generic.DetailView):
     model = Question
     template_name = "polls/detail.html"
 
+    def get_queryset(self):
+        """
+        Excludes any questions that aren't published yet.
+        """
+        return Question.objects.filter(pub_date__lte=timezone.now())
+
 
 class ResultsView(generic.DetailView):
     model = Question

--- a/mysite/polls/views.py
+++ b/mysite/polls/views.py
@@ -22,9 +22,6 @@ class DetailView(generic.DetailView):
     template_name = "polls/detail.html"
 
     def get_queryset(self):
-        """
-        Excludes any questions that aren't published yet.
-        """
         return Question.objects.filter(pub_date__lte=timezone.now())
 
 


### PR DESCRIPTION
-The detail view of a question with a publication date in the future returns a 404 not found.
-The detail view of a question with a publication date in the past displays the question's text.